### PR TITLE
Fix Jest config for ESM

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,6 @@
 export default {
   testEnvironment: 'node',
-  extensionsToTreatAsEsm: ['.js'],
+  // Jest automatically treats files with the `.js` extension as ESM when the
+  // nearest package.json has `"type": "module"`. Removing this option prevents
+  // a validation error in Jest 29+.
 };


### PR DESCRIPTION
## Summary
- fix Jest `extensionsToTreatAsEsm` setting so tests can run under Node's ESM

## Testing
- `npm test -- --runInBand --ci --verbose --forceExit` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1af3d79483238d8b570fd109db26