### PR TITLE
Fix Jest ESM config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 export default {
   testEnvironment: 'node',
-  // Jest automatically treats files with the `.js` extension as ESM when the
-  // nearest package.json has `"type": "module"`. Removing this option prevents
-  // a validation error in Jest 29+.
+  // Ensure Jest treats `.js` files as ES modules so that imports in the server
+  // tests are parsed correctly. Without this Jest attempts to parse them as
+  // CommonJS which causes "Cannot use import statement outside a module" errors.
+  extensionsToTreatAsEsm: ['.js'],
+  transform: {},
 };


### PR DESCRIPTION
## Summary
- adjust Jest configuration so `.js` files are treated as ESM
- disable transforms when running tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a275119e083239963a2fe9f488625