### PR TITLE
Add TypeScript config and enhanced logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Art & Culture Backend
 
 This repository contains an Express API server that uses Prisma for database access. The codebase targets **Node.js 18**.
+Portions of the backend are gradually being migrated to **TypeScript** for improved type safety.
 
 ## Setup
 
@@ -36,6 +37,12 @@ Both commands require the dependencies to be installed locally.
 ## File Uploads
 
 Uploaded files are stored under `server/uploads/` which is ignored by Git.
+
+## Logging
+
+The backend uses **Winston** for centralized logging. Errors are captured by a
+dedicated middleware that returns a consistent JSON structure and writes details
+to the logger.
 
 ## Environment
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,7 @@
 export default {
   testEnvironment: 'node',
-  // Ensure Jest treats `.js` files as ES modules so that imports in the server
-  // tests are parsed correctly. Without this Jest attempts to parse them as
-  // CommonJS which causes "Cannot use import statement outside a module" errors.
-  extensionsToTreatAsEsm: ['.js'],
-  transform: {},
+  extensionsToTreatAsEsm: ['.js', '.ts'],
+  transform: {
+    '^.+\\.(t|j)sx?$': ['ts-jest', { useESM: true }],
+  },
 };

--- a/server/package.json
+++ b/server/package.json
@@ -11,29 +11,28 @@
                 "lint": "eslint .",
                 "format": "prettier --write ."
         },
-	"dependencies": {
-		"@prisma/client": "^5.19.1",
-		"bcrypt": "^5.1.1",
-		"cors": "^2.8.5",
-		"dotenv": "^16.4.5",
-		"express": "^4.19.2",
-		"express-rate-limit": "^7.4.0",
-		"express-validator": "^7.2.0",
-		"jsonwebtoken": "^9.0.2",
-		"morgan": "1.10.0",
-		"multer": "^1.4.5-lts.1",
-		"nodemailer": "^6.9.16",
-		"path": "^0.12.7",
-		"prisma": "^5.19.1",
-		"sharp": "^0.33.5",
-		"winston": "^3.17.0"
-	},
-        "devDependencies": {
+        "dependencies": {
+                "@prisma/client": "^5.19.1",
+                "bcrypt": "^5.1.1",
+                "cors": "^2.8.5",
+                "dotenv": "^16.4.5",
+                "express": "^4.19.2",
+                "express-rate-limit": "^7.4.0",
+                "express-validator": "^7.2.0",
                 "helmet": "^7.1.0",
-                "http-proxy-middleware": "^3.0.0",
-                "morgan": "^1.10.0",
+                "jsonwebtoken": "^9.0.2",
+                "morgan": "1.10.0",
+                "multer": "^1.4.5-lts.1",
+                "nodemailer": "^6.9.16",
+                "prisma": "^5.19.1",
+                "sharp": "^0.33.5",
+                "winston": "^3.17.0"
+        },
+        "devDependencies": {
                 "nodemon": "^3.1.4",
                 "eslint": "^8.46.0",
-                "prettier": "^3.2.5"
+                "prettier": "^3.2.5",
+                "typescript": "^5.8.3",
+                "ts-node": "^10.9.1"
         }
 }

--- a/server/src/middleware/errorHandler.js
+++ b/server/src/middleware/errorHandler.js
@@ -7,12 +7,15 @@ const errorHandler = (err, req, res, next) => {
     return next(err)
   }
 
-  const statusCode = err.name === 'ValidationError' ? 400 : err.status || 500
+  const statusCode = err.status || (err.name === 'ValidationError' ? 400 : 500)
   const message = err.message ||
     (statusCode === 400 ? 'Validation error' : 'Internal Server Error')
   logger.error(`Error handled with status ${statusCode}: ${message}`)
 
-  res.status(statusCode).json({ error: message })
+  res.status(statusCode).json({
+    success: false,
+    message,
+  })
 }
 
 export default errorHandler

--- a/server/src/utils/logging.js
+++ b/server/src/utils/logging.js
@@ -8,9 +8,13 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 const logger = winston.createLogger({
-	level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
-	format: winston.format.json(),
-	transports,
+        level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+        format: winston.format.combine(
+                winston.format.timestamp(),
+                winston.format.errors({ stack: true }),
+                winston.format.json(),
+        ),
+        transports,
 });
 
 //
@@ -18,9 +22,12 @@ const logger = winston.createLogger({
 // `${info.level}: ${info.message} JSON.stringify({ ...rest }) `
 //
 if (process.env.NODE_ENV !== 'production') {
-	logger.add(new winston.transports.Console({
-		format: winston.format.simple(),
-	}));
+        logger.add(new winston.transports.Console({
+                format: winston.format.combine(
+                        winston.format.colorize(),
+                        winston.format.simple(),
+                ),
+        }));
 }
 
 export default logger

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "index.js", "app.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up Winston logging with timestamps and colorized console output
- standardize API error responses
- add TypeScript configuration for the backend
- clean unused dependencies
- document logging and TypeScript migration
- update Jest to support TypeScript

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3f981e9083239788ca211de778dd