### PR TITLE
Fix museum post route path conflict

### DIFF
--- a/server/src/routes/postRoutes.js
+++ b/server/src/routes/postRoutes.js
@@ -52,7 +52,8 @@ router.get("/exhibitions/:id", getPostByExhibitionId)
 
 router.get("/museums", getMuseumsPost)
 
-router.get("/museum/:authorId", getPostsByAuthorId)
+// Get posts by museum author
+router.get("/museum/by-author/:authorId", getPostsByAuthorId)
 
 router.get("/museum/:museumId", getPostByMuseumId)
 


### PR DESCRIPTION
## Summary
- avoid routing conflict under `/museum` by renaming the author-specific path

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aac115c448323a797f31a00539fc4