### PR TITLE
Remove React lint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,10 +1,3 @@
-# ігнорувати всі готові JSX/TSX-файли, крім тих, що під src/app та src/pages
-src/assets/**
-src/screens/**
-src/data/**
-src/utils/**
-src/index.js
-src/App.jsx
-src/routes/**
-src/pages/_app.tsx
-src/pages/ssr.js
+# Ignore generated or third party code
+node_modules/
+server/uploads/

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,38 +5,25 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2022,
     sourceType: 'module',
-    ecmaFeatures: { jsx: true },
   },
   plugins: [
     '@typescript-eslint',
-    'react',
-    'react-hooks',
-    'jsx-a11y',
     'import',
-    '@next/next',
   ],
   extends: [
-    'plugin:@next/next/core-web-vitals',
     'plugin:@typescript-eslint/recommended',
-    'plugin:react/recommended',
-    'plugin:react-hooks/recommended',
-    'plugin:jsx-a11y/recommended',
     'plugin:import/errors',
     'plugin:import/warnings',
     'plugin:import/typescript'
   ],
   settings: {
-    react: { version: 'detect' },
     'import/resolver': {
-      node: { extensions: ['.js', '.jsx', '.ts', '.tsx'] },
+      node: { extensions: ['.js', '.ts'] },
     },
   },
   rules: {
-    'react/prop-types': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
-    'react-refresh/only-export-components': 'off',
-    'react/react-in-jsx-scope': 'off'
   },
-  ignorePatterns: ['.next/', 'node_modules/', 'public/'],
+  ignorePatterns: ['node_modules/'],
 };

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,39 +3,27 @@
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2023,
-    "sourceType": "module",
-    "ecmaFeatures": { "jsx": true }
+    "sourceType": "module"
   },
   "plugins": [
-    "react",
-    "react-hooks",
-    "jsx-a11y",
     "@typescript-eslint",
     "import"
   ],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:react/recommended",
-    "plugin:react-hooks/recommended",
-    "plugin:jsx-a11y/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:import/typescript",
-    "next",
-    "next/core-web-vitals"
+    "plugin:import/typescript"
   ],
   "settings": {
-    "react": { "version": "detect" },
     "import/resolver": {
-      "node": { "extensions": [".js", ".jsx", ".ts", ".tsx"] }
+      "node": { "extensions": [".js", ".ts"] }
     }
   },
   "rules": {
-    "react/prop-types": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "react-hooks/exhaustive-deps": "warn",
     "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
   },
-  "ignorePatterns": [".next/", "node_modules/", "public/"]
+  "ignorePatterns": ["node_modules/"]
 }


### PR DESCRIPTION
## Summary
- drop Next.js and React rules from ESLint configs
- clean up `.eslintignore`

## Testing
- `npx eslint -c ../.eslintrc.cjs .` *(fails: A config object is using the "root" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_684aadc0ba908323b6506ae8b8d09457