### PR TITLE
Remove leftover imports after static removal

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,15 +1,9 @@
 import prisma from './prismaClient.js'
 import dotenv from 'dotenv'
-import express from 'express'
-import path from 'path'
-import { fileURLToPath } from 'url'
 import app from './app.js'
 import logger from './src/utils/logging.js'
 
 dotenv.config()
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
 
 // Define PORT
 const PORT = process.env.PORT || 5000 // Use a port that doesn't conflict with your frontend


### PR DESCRIPTION
## Summary
- remove unused express, path and url imports from `server/index.js`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aadcb583483239022fd17c072b44b