### PR TITLE
Configure Jest for ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ Portions of the backend are gradually being migrated to **TypeScript** for impro
 
 ## Tests and Linting
 
-Dev dependencies such as Jest and ESLint are installed with `npm install` in the `server` directory. Run the following commands from `server`:
+Dev dependencies such as Jest and ESLint are installed with `npm install` in the `server` directory. Tests live under `server/tests` and must be executed from that folder.
 
 ```bash
+cd server
 npm run lint
 npm test
 ```
 
-Both commands require the dependencies to be installed locally.
+Both commands require the dependencies to be installed locally inside `server`.
 
 ## File Uploads
 

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,6 +1,10 @@
 export default {
+  preset: 'ts-jest/presets/js-with-ts-esm',
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.js', '.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   transform: {
     '^.+\\.(t|j)sx?$': ['ts-jest', { useESM: true }],
   },


### PR DESCRIPTION
## Summary
- clarify how to run tests from the `server` folder
- configure Jest with `ts-jest` ESM preset

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aadeb6c90832394f08b0b43b39c26