### PR TITLE
Update README with test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ Portions of the backend are gradually being migrated to **TypeScript** for impro
 
 ## Tests and Linting
 
-Dev dependencies such as Jest and ESLint are installed with `npm install` in the `server` directory. Run the following commands from `server`:
+Dev dependencies such as Jest and ESLint are installed with `npm install` in the `server` directory. Run the following commands from **inside** the `server` folder:
 
 ```bash
+cd server
 npm run lint
 npm test
 ```
 
-Both commands require the dependencies to be installed locally.
+The `test` script executes `jest --runInBand`, so your tests are run sequentially. Both commands require the dependencies to be installed locally.
 
 ## File Uploads
 

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,7 +1,10 @@
 export default {
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.js', '.ts'],
-  transform: {
-    '^.+\\.(t|j)sx?$': ['ts-jest', { useESM: true }],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
   },
 };


### PR DESCRIPTION
## Summary
- clarify README instructions for running lint & tests
- refine Jest config to use ESM preset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aac1c6b108323816c5332f9305b64