### PR TITLE
Add tsconfig for TypeScript setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Portions of the backend are gradually being migrated to **TypeScript** for impro
    npx --prefix server prisma generate
    npx --prefix server prisma migrate deploy
    ```
-4. Start the development server:
+4. The TypeScript configuration used by the API lives in `server/tsconfig.json`.
+5. Start the development server:
    ```bash
    npm run dev --prefix server
    ```

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": [
+    "src/**/*",
+    "*.js",
+    "tests/**/*.js"
+  ],
+  "ts-node": {
+    "esm": true
+  }
+}


### PR DESCRIPTION
## Summary
- add a basic `tsconfig.json` inside `server`
- document location of TypeScript configuration in README

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acf99aa4c8323aebaa13d0ca3cb1e