### PR TITLE
Fix obsolete entries in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,5 @@ node_modules/
 
 # Резервні/бекап-файли
 *.bak
-
-# Дублікати lock-файлів та модулів
-package-lock 2.json
-node_modules 2/
-
 # IDE та тестові артефакти
 server/uploads/


### PR DESCRIPTION
## Summary
- remove outdated duplicate ignore rules

## Testing
- `npm test --prefix server` *(fails: jest not found)*
- `npm run lint --prefix server` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad09fcd10832390a1e409d0f20b3b